### PR TITLE
hotfix 8.0.7

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: alinea.caribu
-  version: 8.0.1
+  version: 8.0.7
 
 source:
   path: ..

--- a/src/alinea/caribu/caribu_shell.py
+++ b/src/alinea/caribu/caribu_shell.py
@@ -308,7 +308,7 @@ class Caribu(object):
     def copyfiles(self, skip_sky=False, skip_pattern=False, skip_opt=False):
         d = self.tempdir
 
-        if os.path.exists(self.scene):
+        if str(self.scene).endswith('.can'):
             fn = Path(self.scene)
             fn.copy(d / fn.basename())
         else:

--- a/src/alinea/caribu/version.py
+++ b/src/alinea/caribu/version.py
@@ -15,7 +15,7 @@
 
 major = 8
 minor = 0
-post = 6
+post = 7
 
 __version__ = ".".join([str(s) for s in (major, minor, post)])
 # #}


### PR DESCRIPTION
correct bug in caribu/caribu_shell.py when checking for path with too long strings for Windows (see #44).

For future versions: 'self.scene' should not be either the file name or the file content.